### PR TITLE
Fix syntax error in student profile view

### DIFF
--- a/studentProfileView.js
+++ b/studentProfileView.js
@@ -231,7 +231,7 @@ const studentProfileView = {
       scheduleCheckContainer.appendChild(tbl);
       confirmArchiveBtn.disabled = false;
     });
-    +  confirmArchiveBtn.addEventListener('click', () => {
+    confirmArchiveBtn.addEventListener('click', () => {
     const ym       = archiveSinceInput.value;                    // “YYYY-MM”
     const monthMap = monthlySchedulesByMonth[ym] || {};          // grab that month
     const sched    = monthMap[currentStudent.id] || [];


### PR DESCRIPTION
## Summary
- fix stray `+` that broke the archive modal

## Testing
- `node --check studentProfileView.js`
- `node --check teacherView.js`
- `node --check monthlyView.js`
- `node --check printingBillView.js`
- `node --check daysOffView.js`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_684946a1f7d8832e9605f71b8ce01ab5